### PR TITLE
modification on the bibliography syntax

### DIFF
--- a/_extras/design.md
+++ b/_extras/design.md
@@ -27,19 +27,21 @@ submit a MD simulation.  There are numerous good GROMACS tutorials available and
 maybe one of them could be adapted for this.  In addition to general instructions 
 and commands, there should be specific instructions on how to do this on Compute 
 Canada clusters.  As in Software Carpentry lessons, certain steps should be 
-implelemented as exercises for the learner - the correct answer can be hidden in 
+implemented as exercises for the learner - the correct answer can be hidden in 
 an answer box.  
 Theory should be skipped over as much as possible and should be covered in the 
 second module.  
 This lesson could be adapted for other MD-codes (e.g. NAMD) as well.
+
 
 The **second lesson** is a small theory review to remind the learners of important 
 concepts and how they influence the choice of simulation parameters.  The aim is
 that people can avoid pit-falls and misunderstandings that are commonly made
 by novice MD users. Topics to cover are Periodic Boundary Conditions (and why 
 there is no "outside" with a periodic box), thermostats/barostats, cut-offs, etc.  
-This shold be no substitute for a formal course in statistical thermodynamics 
+This should be no substitute for a formal course in statistical thermodynamics 
 but should help users make more informed choices of simulation settings/parameters.
+
 
 The **third lesson** is again a hands-on tutorial to use Python and the Python 
 packages [MDAnalysis](https://www,mdanalysis.org), [MDtraj](http://mdtraj.org/),
@@ -49,6 +51,17 @@ tools out-of-the-box, users often limit themselves to those tools and the option
 and variations that they offer.  The above frameworks make it very easy to read 
 MD-trajectories in different formats and get access to the coordinates and come 
 up with fully customized analysis methods.
+
+
+The mentioned lessons *one* and *three* are currently put on hold and are subject
+to be created at a later time.  In the meantime we can recommend to work through
+online tutorials that are already available such as:
+* http://www.mdtutorials.com/ 
+* https://www.mdanalysis.org/MDAnalysisTutorial/
+
+This module here will implement the *second lesson* focusing on theory and giving
+guidance on choosing good parameters for MD-Simulations.
+
 
 ## Process Used
 

--- a/_extras/design.md
+++ b/_extras/design.md
@@ -132,8 +132,8 @@ up with fully customized analysis methods.
     * Flying ice cube -> resetting COM-movement
     * Hot-Solvent/Cold-Solute -> tcoupl groups
     * Literature:
-        * [Basconi2013]({{ page.root }}/reference.html#Basconi2013)
-        * [Wong-ekkabut2016]({{ page.root }}/reference.html#Wong-ekkabut2016)
+        * [Basconi2013]({{ page.root }}/reference.html#Basconi-2013)
+        * [Wong-ekkabut2016]({{ page.root }}/reference.html#Wong-ekkabut-2016)
 
 * Parallelization/Performance
     * Particle decomposition vs. Domain Decomposition
@@ -141,7 +141,7 @@ up with fully customized analysis methods.
     * PME nodes /  shifting of real-space/PME cutoff
     * Load balancing
     * Literature:
-        * [Larsson2011]({{ page.root }}/reference.html#Larsson2011)
+        * [Larsson2011]({{ page.root }}/reference.html#Larsson-2011)
 
 ### Questions
 

--- a/reference.md
+++ b/reference.md
@@ -7,9 +7,29 @@ root: .
 
 FIXME
 
+{:auto_ids}
+barostat
+:   Pressure control algorithms in molecular dynamics (MD) simulations are commonly referred to
+    as barostats and are needed to study isobaric systems.  Barostats work by altering the 
+    size of the simulation box.  Therefore they can only be used in conjunction with 
+    [periodic boundary conditions (PBC)](#periodic-boundary-conditions).
+
+periodic boundary conditions
+:   Periodic boundary conditions (PBC) ...  
+    See also:
+    * ["Periodic boundary conditions" in Wikipedia](https://en.wikipedia.org/wiki/Periodic_boundary_conditions)  
+    * ["Periodic boundary conditions" on gromacs.org](http://www.gromacs.org/Documentation/Terminology/Periodic_Boundary_Conditions)
+
+thermostat
+:   Temperature control algorithms in molecular dynamics (MD) simulations are commonly referred to
+    as thermostats and are needed to study isothermal systems.  Thermostats work by altering the 
+    velocities of particles.
+
+
 ## Bibliography
 
 {% comment %}
+
 Add items to the Bibliography using the following template and add it in the right
 location sorted by RefnameYYYY.
 
@@ -22,43 +42,52 @@ The Style is PLOS ONE with separate lines for:
 
 e.g.:
 
-* <a name="RefnameYYYY" />**RefnameYYYY**:
-  List OF, Author S.  
-  *Title of the paper -  PLOS ONE style*  
-  PLoS ONE. 2019;1. doi:10.1371/journal.pone.0000000 
+Refname-YYYY
+:   List OF, Author S.  
+    *Title of the paper -  PLOS ONE style*  
+    PLoS ONE. 2019;1. doi:10.1371/journal.pone.0000000 
 
 You can add links to this entry by using on any page:
 
-[RefnameYYYY]({{ page.root }}/reference.html#RefnameYYYY)
+[RefnameYYYY]({{ page.root }}/reference.html#Refname-YYYY)
 
 {% endcomment %}
 
 
-* <a name="Allen2017" />**Allen2017**: 
-  Allen MP, Tildesley DJ.  
-  *Computer Simulation of Liquids. Second Edition*  
-  Oxford University Press; 2017. ISBN: 9780198803195 [doi:10.1093/oso/9780198803195.001.0001](http://dx.doi.org/10.1093/oso/9780198803195.001.0001)
-* <a name="Basconi2013" />**Basconi2013**: 
-  Basconi JE, Shirts MR.  
-  *Effects of Temperature Control Algorithms on Transport Properties and Kinetics in Molecular Dynamics Simulations.*  
-  J Chem Theory Comput. 2013;9: 2887–2899.  [doi:10.1021/ct400109a](http://dx.doi.org/10.1021/ct400109a)
-<!-- * <a name="Gowers2016" />**Gowers2016**: 
-  Gowers RJ, Linke M, Barnoud J, Reddy TJE, Melo MN, Seyler SL, et al.  
-  *MDAnalysis: A Python Package for the Rapid Analysis of Molecular Dynamics Simulations.*  
-  Proc 15th Python Sci Conf. 2016; 98–105. Available: http://conference.scipy.org/proceedings/scipy2016/pdfs/oliver_beckstein.pdf -->
-* <a name="Larsson2011" />**Larsson2011**: 
-  Larsson P, Hess B, Lindahl E.  
-  *Algorithm improvements for molecular dynamics simulations.*  
-  Wiley Interdiscip Rev Comput Mol Sci. 2011;1: 93–108. [doi:10.1002/wcms.3](http://dx.doi.org/doi:10.1002/wcms.3)
-<!-- * <a name="Merz2018" />**Merz2018**:
-  Merz PT, Shirts MR.  
-  *Testing for physical validity in molecular simulations.*  
-  Huang X, editor. PLoS One. 2018;13: e0202764. [doi:10.1371/journal.pone.0202764](http://dx.doi.org/10.1371/journal.pone.0202764) -->
-<!-- * <a name="Michaud-Agrawal2011" />**Michaud-Agrawal2011**: 
-  Michaud-Agrawal N, Denning EJ, Woolf TB, Beckstein O.   
-  *MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.*  
-  J Comput Chem. 2011;32: 2319–27. [doi:10.1002/jcc.21787](http://dx.doi.org/10.1002/jcc.21787) -->
-* <a name="Wong-ekkabut2016" />**Wong-ekkabut2016**: 
-  Wong-ekkabut J, Karttunen M. 
-  *The good, the bad and the user in soft matter simulations.*  
-  Biochim Biophys Acta - Biomembr. Elsevier B.V.; 2016;1858: 2529–2538. [doi:10.1016/j.bbamem.2016.02.004](http://dx.doi.org/10.1016/j.bbamem.2016.02.004)
+{:auto_ids}
+Allen-2017
+:   Allen MP, Tildesley DJ.  
+    *Computer Simulation of Liquids. Second Edition*  
+    Oxford University Press; 2017. ISBN: 9780198803195 [doi:10.1093/oso/9780198803195.001.0001](http://dx.doi.org/10.1093/oso/9780198803195.001.0001)
+
+Basconi-2013
+:   Basconi JE, Shirts MR.  
+    *Effects of Temperature Control Algorithms on Transport Properties and Kinetics in Molecular Dynamics Simulations.*  
+    J Chem Theory Comput. 2013;9: 2887–2899.  [doi:10.1021/ct400109a](http://dx.doi.org/10.1021/ct400109a)
+
+<!-- 
+Gowers-2016
+:   Gowers RJ, Linke M, Barnoud J, Reddy TJE, Melo MN, Seyler SL, et al.  
+    *MDAnalysis: A Python Package for the Rapid Analysis of Molecular Dynamics Simulations.*  
+    Proc 15th Python Sci Conf. 2016; 98–105. Available: http://conference.scipy.org/proceedings/scipy2016/pdfs/oliver_beckstein.pdf -->
+
+Larsson-2011
+:   Larsson P, Hess B, Lindahl E.  
+    *Algorithm improvements for molecular dynamics simulations.*  
+    Wiley Interdiscip Rev Comput Mol Sci. 2011;1: 93–108. [doi:10.1002/wcms.3](http://dx.doi.org/doi:10.1002/wcms.3)
+
+<!--
+Merz-2018
+:   Merz PT, Shirts MR.  
+    *Testing for physical validity in molecular simulations.*  
+    Huang X, editor. PLoS One. 2018;13: e0202764. [doi:10.1371/journal.pone.0202764](http://dx.doi.org/10.1371/journal.pone.0202764) -->
+<!--
+Michaud-Agrawal-2011
+:    Michaud-Agrawal N, Denning EJ, Woolf TB, Beckstein O.   
+    *MDAnalysis: A Toolkit for the Analysis of Molecular Dynamics Simulations.*  
+    J Comput Chem. 2011;32: 2319–27. [doi:10.1002/jcc.21787](http://dx.doi.org/10.1002/jcc.21787) -->
+
+Wong-ekkabut-2016
+:   Wong-ekkabut J, Karttunen M.  
+    *The good, the bad and the user in soft matter simulations.*  
+    Biochim Biophys Acta - Biomembr. Elsevier B.V.; 2016;1858: 2529–2538. [doi:10.1016/j.bbamem.2016.02.004](http://dx.doi.org/10.1016/j.bbamem.2016.02.004)


### PR DESCRIPTION
When looking into how the official Software Carpentry lessons create their glossary, I've discovered a better way to build our bibliography. 

It uses the Markdown syntax for definition lists and is IMHO much more readable.

One can define a reference with:

```
Refname-YYYY
:   List OF, Author S.  
    *Title of the paper -  PLOS ONE style*  
    PLoS ONE. 2019;1. doi:10.1371/journal.pone.0000000 
```

and use it with:

`[Link-text, e.g. Refname-YYYY]({{ page.root }}/reference.html#Refname-YYYY)`

As a subtle change I've changed the format for Reference-IDs to include a dash between the name and the year, because I feel that it's more readable than without.

